### PR TITLE
Add Tinybase to state management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A curated list of local-first software, resources, and development tools. Local-
 - [Replicache](https://replicache.dev) - Client-side state management with automatic sync
 - [PowerSync](https://www.powersync.com) - Offline-first sync engine for mobile and web apps
 - [Y-Sweet](https://jamsocket.com/y-sweet) - Backend service for Yjs CRDT sync
+- [Tinybase](https://github.com/tinyplex/tinybase) - A reactive data store & sync engine
 
 ### CRDT Libraries
 - [Automerge](https://automerge.org/) - CRDT library with automatic merging and cross-platform support


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Tinybase to the "State Management & Sync" section with a description and link.
  * Added a newline at the end of the README file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->