### PR TITLE
 Add AhaKnow Chat to Awesome Local-First

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Anytype](https://anytype.io) – Local-first, P2P, E2E encrypted knowledge OS
 - [AFFiNE](https://affine.pro) – Open-source workspace combining docs, whiteboards, and databases
 - [AppFlowy](https://appflowy.com) – Open-source Notion alternative with full offline mode
+- [AhaKnow Chat](https://github.com/IHKYoung/AhaKnowChat) – Open-source local-first AI chat workspace with topic-based threads, reusable roles, and browser-native storage for prompt testing and personal knowledge exploration
 - [Standard Notes](https://standardnotes.com) – Open-source, E2E encrypted notes
 - [Joplin](https://joplinapp.org) – Open-source offline-first note-taking with optional E2E sync
 - [Notesnook](https://notesnook.com) – Open-source zero-knowledge encrypted notes


### PR DESCRIPTION
## Summary

This PR adds AhaKnow Chat to the `Knowledge Management & Notes` section of Awesome Local-First.

AhaKnow Chat is an open-source local-first AI chat workspace for prompt testing, topic-based threads, reusable roles, and personal knowledge exploration. It stores data locally in the browser for the web version and is designed around local ownership of conversation history and configuration.

## Why it fits

- local-first data storage in the web client
- user-owned conversation history and settings
- useful for personal knowledge exploration and iterative thinking
- topic/thread organization instead of a purely transient chat surface

## Changes

- Add one entry to `README.md` under `Example Applications -> Knowledge Management & Notes`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AhaKnow Chat to the example applications list in the Knowledge Management & Notes section. This open-source tool provides a local-first AI chat workspace with topic-based threads and reusable roles for prompt testing and personal knowledge exploration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->