### PR TITLE
Add Socratic Council to Productivity & Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Huly](https://huly.io) – Open-source all-in-one project management platform with offline-first client
 - [Superhuman](https://superhuman.com) – Offline-first email client
 - [GitComet](https://github.com/Auto-Explore/GitComet) – Open-source (AGPL-3.0) local-first Git GUI in Rust for Linux, macOS, and Windows
+- [Socratic Council](https://github.com/richer-richard/socratic-council) – Local-first desktop app for AI Socratic seminars with 16 multi-provider agents, argument mapping, and encrypted file vault
 
 **Personal & Finance**
 - [Actual](https://actualbudget.com) – Local-first budgeting


### PR DESCRIPTION
Adding **Socratic Council** to **Example Applications → Productivity & Collaboration**.

- Repo: https://github.com/richer-richard/socratic-council
- License: Apache-2.0
- Stack: Tauri 2 (Rust + React/TS) desktop app; no backend, no telemetry

**Local-first dimensions:**
- All data lives on the user's machine — sessions, transcripts, and provider API keys are stored in a file-based encrypted vault (XChaCha20-Poly1305).
- No required network round-trip for non-LLM operations; provider seats accept any OpenAI-compatible base URL, so a fully local seminar runs against Ollama / vLLM / LM Studio.
- Exports are single-file `.scbundle` archives — explicit transport rather than live sync.

Sync/CRDT: not applicable in v2.0.0. If this list strictly tracks CRDT/sync-engine projects, please close and let me know — happy to revise or withdraw.

Thanks for maintaining the list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Socratic Council" to the example applications section as a reference local-first desktop application for productivity and collaboration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->