### PR TITLE
Add nobro.app under new Health & Fitness subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Finbodhi (2025)](https://finbodhi.com) – Encrypted personal-finance app
 - [Timelinize (2025)](https://timelinize.com) – Local data aggregation into a personal timeline
 
+**Health & Fitness**
+- [nobro.app](https://nobro.app/) – Minimalist offline-first workout program tracker. State lives in localStorage, program is editable JSON, 11 locales
+
 ### Learning Resources
 - [SQLite in Vue Guide](https://alexop.dev/posts/sqlite-vue3-offline-first-web-apps-guide/) – Building offline-first Vue apps
 - [An Interactive Intro to CRDTs](https://jakelazaroff.com/words/an-interactive-intro-to-crdts/) – Hands-on tutorial


### PR DESCRIPTION
Adding **nobro.app**, a local-first workout program tracker, under a new **Health & Fitness** subsection in Example Applications.

- Live: https://nobro.app/
- Source: https://github.com/mybottles/nobro-app (MIT)
- Local-first: state and editable program both stored in `localStorage`, no backend
- Offline-capable PWA, no accounts, no tracking
- 11 locales

Tagline: *no thinking. just lift.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Health & Fitness" subsection to the README's "Example Applications" section with an additional example application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->