### PR TITLE
Add EchoTalk – offline language practice PWA (new Language Learning subsection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [SwarmVault](https://swarmvault.ai) – Local-first RAG knowledge vault. Compiles raw sources into a durable markdown wiki with a knowledge graph and hybrid SQLite FTS plus embeddings. All data lives on disk; AI access via a local MCP server.
 
 **Language Learning**
-- [EchoTalk](https://alisolphp.github.io/EchoTalk/) - Privacy-first offline shadowing practice PWA. AI pronunciation feedback, local recordings, no account needed.
+- [EchoTalk](https://alisolphp.github.io/EchoTalk/) – Privacy-first offline shadowing practice PWA. AI pronunciation feedback, local recordings, no account needed.
 
 **Productivity & Collaboration**
 - [Excalidraw](https://excalidraw.com) – Collaborative drawing

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Obsidian](https://obsidian.md) – Markdown-based knowledge management with local vault storage
 - [SwarmVault](https://swarmvault.ai) – Local-first RAG knowledge vault. Compiles raw sources into a durable markdown wiki with a knowledge graph and hybrid SQLite FTS plus embeddings. All data lives on disk; AI access via a local MCP server.
 
+**Language Learning**
+- [EchoTalk](https://alisolphp.github.io/EchoTalk/) - Privacy-first offline shadowing practice PWA. AI pronunciation feedback, local recordings, no account needed.
+
 **Productivity & Collaboration**
 - [Excalidraw](https://excalidraw.com) – Collaborative drawing
 - [tldraw](https://tldraw.com) – Open-source infinite canvas whiteboard SDK


### PR DESCRIPTION
This PR adds EchoTalk, a local-first PWA for language shadowing practice, to the Example Applications section. I've proposed a new "Language Learning" subsection since existing categories don't fit well — happy to adjust if preferred.

### About EchoTalk
- Works fully offline after first load (service worker, IndexedDB).
- No account, no server – all recordings and progress stay on user's device.
- AI pronunciation analysis, adjustable TTS, multi-language support.
- MIT licensed, 200+ unit tests.
- Live: https://alisolphp.github.io/EchoTalk/
- Repo: https://github.com/alisolphp/EchoTalk

Thanks for maintaining this great list!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new EchoTalk example app to the Example Applications under a Language Learning subsection, including a link and short description.
  * Adjusted the surrounding application list ordering so numbering and sections remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->