### PR TITLE
feat: Add Filarr to Knowledge Management & Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Obsidian](https://obsidian.md) – Markdown-based knowledge management with local vault storage
 - [SwarmVault](https://swarmvault.ai) – Local-first RAG knowledge vault. Compiles raw sources into a durable markdown wiki with a knowledge graph and hybrid SQLite FTS plus embeddings. All data lives on disk; AI access via a local MCP server.
 - [Memex](https://github.com/memex-lab/memex) – Open-source, local-first AI journal for iOS and Android. A multi-agent system turns text, photo, and voice fragments into structured timeline cards, and organizes knowledge using the P.A.R.A. methodology. All data is stored on-device (filesystem + SQLite) and users bring their own LLM provider. [Website](https://www.memexlab.ai/)
+- [Filarr](https://filarr.com) – Encrypted local-first workspace combining notes, files, knowledge graph and canvas. AES-256-GCM per-file encryption with KEK/FEK key wrapping, optional zero-knowledge cloud sync. Desktop client open source under BSL 1.1.
 
 **Language Learning**
 - [EchoTalk](https://alisolphp.github.io/EchoTalk/) – Privacy-first offline shadowing practice PWA. AI pronunciation feedback, local recordings, no account needed.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Obsidian](https://obsidian.md) – Markdown-based knowledge management with local vault storage
 - [SwarmVault](https://swarmvault.ai) – Local-first RAG knowledge vault. Compiles raw sources into a durable markdown wiki with a knowledge graph and hybrid SQLite FTS plus embeddings. All data lives on disk; AI access via a local MCP server.
 - [Memex](https://github.com/memex-lab/memex) – Open-source, local-first AI journal for iOS and Android. A multi-agent system turns text, photo, and voice fragments into structured timeline cards, and organizes knowledge using the P.A.R.A. methodology. All data is stored on-device (filesystem + SQLite) and users bring their own LLM provider. [Website](https://www.memexlab.ai/)
-- [Filarr](https://filarr.com) – Encrypted local-first workspace combining notes, files, knowledge graph and canvas. AES-256-GCM per-file encryption with KEK/FEK key wrapping, optional zero-knowledge cloud sync. Desktop client open source under BSL 1.1.
+- [Filarr](https://filarr.com) – Encrypted local-first workspace combining notes, files, knowledge graph and canvas. AES-256-GCM per-file encryption with KEK/FEK key wrapping, optional zero-knowledge cloud sync. Desktop client open source under BSL 1.1. [Repository](https://github.com/matbel91765/filarr)
 
 **Language Learning**
 - [EchoTalk](https://alisolphp.github.io/EchoTalk/) – Privacy-first offline shadowing practice PWA. AI pronunciation feedback, local recordings, no account needed.


### PR DESCRIPTION
Adding Filarr — encrypted local-first workspace (notes + files + graph + canvas). Native AES-256-GCM per-file encryption, optional zero-knowledge cloud sync, desktop client open source under BSL 1.1.

Website: https://filarr.com 
Repo: https://github.com/matbel91765/filarr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Filarr" entry to Example Applications → Knowledge Management & Notes, describing its encrypted local-first workspace for notes, files, a knowledge graph and canvas.
  * Notes inclusion highlights optional zero-knowledge cloud sync, a link to the project, and desktop client licensing (open-source under BSL 1.1).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderop/awesome-local-first/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->