### PR TITLE
Add KaChiKa to Language Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 
 **Language Learning**
 - [EchoTalk](https://alisolphp.github.io/EchoTalk/) – Privacy-first offline shadowing practice PWA. AI pronunciation feedback, local recordings, no account needed.
-- [KaChiKa](https://kachika.app/) – Local-first AI photo-to-flashcard app for language learners. Snap a photo of any real-world object and KaChiKa extracts vocabulary with example sentences. All images are processed and stored on-device (no upload), with FSRS-based spaced repetition for review scheduling. iOS, Android, APK. 7 languages supported (EN/JA/FR/KO/IT/ES/ZH).
+- [KaChiKa](https://kachika.app/) – Local-first AI photo-to-flashcard app for language learners. Snap a photo of a real-world object and KaChiKa extracts vocabulary with example sentences. All images are processed and stored on-device — no upload. Uses spaced repetition for review scheduling. Available on [iOS](https://apps.apple.com/app/id6740193802) and [Android](https://play.google.com/store/apps/details?id=com.hugo.photoen).
 
 **Productivity & Collaboration**
 - [Excalidraw](https://excalidraw.com) – Collaborative drawing

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 
 **Language Learning**
 - [EchoTalk](https://alisolphp.github.io/EchoTalk/) – Privacy-first offline shadowing practice PWA. AI pronunciation feedback, local recordings, no account needed.
+- [KaChiKa](https://kachika.app/) – Local-first AI photo-to-flashcard app for language learners. Snap a photo of any real-world object and KaChiKa extracts vocabulary with example sentences. All images are processed and stored on-device (no upload), with FSRS-based spaced repetition for review scheduling. iOS, Android, APK. 7 languages supported (EN/JA/FR/KO/IT/ES/ZH).
 
 **Productivity & Collaboration**
 - [Excalidraw](https://excalidraw.com) – Collaborative drawing


### PR DESCRIPTION
## Summary

Adds [KaChiKa](https://kachika.app/) to the **Real-World Examples → Example Applications → Language Learning** subsection.

## Why it fits awesome-local-first

KaChiKa is a **photo-to-flashcard language learning app** that runs entirely on-device:

- **Local-first data**: every photo a user snaps is processed and stored locally — there is **no image upload** to any server
- **Offline review**: once vocabulary is captured, flashcard reviews run fully offline using FSRS-scheduled cards
- **Data ownership**: photos and learning history live on the user's device; the app does not require an account to use the core flashcard loop

This matches the core principles called out in this repo's intro: **data ownership, offline functionality**.

## Why the Language Learning subsection

KaChiKa is purpose-built for language vocabulary learning — currently this subsection has only EchoTalk (a pronunciation-focused PWA). KaChiKa complements it as the **vocabulary-acquisition** counterpart in the same privacy-first spirit.

## Entry details

- **Website**: https://kachika.app
- **Platforms**: iOS (App Store), Android (Play Store), APK
- **Languages supported**: English, Japanese, French, Korean, Italian, Spanish, Chinese
- **SRS algorithm**: FSRS (Free Spaced Repetition Scheduler)
- **License model**: Free with optional subscription

## Checklist
- [x] Format matches existing entries (bullet, name + link, em-dash, one-paragraph description)
- [x] App actively maintained and publicly available
- [x] Local-first claim is real: images never leave the device
- [x] Description is factual, no marketing fluff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "KaChiKa" Language Learning entry to the README describing photo-to-flashcards vocabulary extraction, on-device image processing, spaced repetition review scheduling, and supported platforms (iOS and Android).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderop/awesome-local-first/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->