### PR TITLE
add authsome under Auth &amp; Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 ### Auth & Identity
 - [UCAN](https://ucan.xyz) – Trustless, offline-capable, delegated authorization tokens using DIDs
 - [DID (Decentralized Identifiers)](https://www.w3.org/TR/did-1.1/) – W3C standard for verifiable, self-sovereign digital identity
+- [authsome](https://github.com/agentrhq/authsome) – Local-first credential broker for AI agents. OAuth2 and API key vault stored under `~/.authsome`, a local HTTPS proxy on loopback injects credentials into outbound provider requests so the agent never sees raw secrets. 45 providers bundled. No cloud account, no SaaS dependency. Python, MIT.
 
 ### Security & Encryption
 - [OpenMLS](https://openmls.tech) – Rust implementation of the Messaging Layer Security (MLS) protocol for E2E encrypted group communication

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 ### Auth & Identity
 - [UCAN](https://ucan.xyz) – Trustless, offline-capable, delegated authorization tokens using DIDs
 - [DID (Decentralized Identifiers)](https://www.w3.org/TR/did-1.1/) – W3C standard for verifiable, self-sovereign digital identity
-- [authsome](https://github.com/agentrhq/authsome) – Local-first credential broker for AI agents. OAuth2 and API key vault stored under `~/.authsome`, a local HTTPS proxy on loopback injects credentials into outbound provider requests so the agent never sees raw secrets. 45 providers bundled. No cloud account, no SaaS dependency. Python, MIT.
+- [authsome](https://github.com/agentrhq/authsome) – Local-first credential broker for AI agents with OAuth2 and API key vault. Python, MIT.
 
 ### Security & Encryption
 - [OpenMLS](https://openmls.tech) – Rust implementation of the Messaging Layer Security (MLS) protocol for E2E encrypted group communication


### PR DESCRIPTION
hey, opening this to add authsome under Auth & Identity, next to UCAN and DID.

authsome is a local-first credential broker for AI agents. log in once via OAuth2 (browser PKCE or device code) or API key, the encrypted vault sits under ~/.authsome, and a local HTTPS proxy on loopback injects credentials into outbound provider requests so the agent's process environment never holds raw secrets. 45 providers bundled (14 OAuth2, 31 API key) including github, google, openai, linear, slack, notion, resend, stripe. background token refresh, no cloud account, no SaaS dependency.

it's a local-first fit because the credential vault never leaves the user's machine, the proxy runs only on loopback, and the daemon does all OAuth/API work locally. the only outbound traffic is to the user-chosen providers themselves (e.g. github.com, openai.com), not to any Agentr-hosted service.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT
pypi: https://pypi.org/project/authsome/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Auth & Identity" resource entry describing "authsome" — a Python, MIT‑licensed local-first credential broker for AI agents that provides OAuth2 support and an API key vault.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->