### PR TITLE
Add Screenpipe to Example Applications / Knowledge Management & Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Obsidian](https://obsidian.md) – Markdown-based knowledge management with local vault storage
 - [SwarmVault](https://swarmvault.ai) – Local-first RAG knowledge vault. Compiles raw sources into a durable markdown wiki with a knowledge graph and hybrid SQLite FTS plus embeddings. All data lives on disk; AI access via a local MCP server.
 - [Memex](https://github.com/memex-lab/memex) – Open-source, local-first AI journal for iOS and Android. A multi-agent system turns text, photo, and voice fragments into structured timeline cards, and organizes knowledge using the P.A.R.A. methodology. All data is stored on-device (filesystem + SQLite) and users bring their own LLM provider. [Website](https://www.memexlab.ai/)
+- [Screenpipe](https://github.com/screenpipe/screenpipe) – Local-first screen and audio recorder that indexes OCR, accessibility data, and transcripts into a searchable timeline for people and AI agents. Data stays on disk by default; cross-platform (macOS/Windows/Linux); works with local models. Source-available under the Screenpipe Commercial License; earlier MIT-licensed versions remain under MIT. [Website](https://screenpipe.com)
 
 **Language Learning**
 - [EchoTalk](https://alisolphp.github.io/EchoTalk/) – Privacy-first offline shadowing practice PWA. AI pronunciation feedback, local recordings, no account needed.


### PR DESCRIPTION
Adds screenpipe under Example Applications > Knowledge Management & Notes.

screenpipe is a local-first screen and audio recorder that indexes OCR, accessibility data, and transcripts into a searchable timeline for people and AI agents. Capture data stays on disk by default, it supports macOS, Windows, and Linux, and it can work with local models.

- Repo: https://github.com/screenpipe/screenpipe
- Website: https://screenpipe.com
- Current license: source-available under the Screenpipe Commercial License; earlier MIT-licensed versions remain under MIT
- License source: https://github.com/screenpipe/screenpipe/blob/main/LICENSE.md

Disclosure: I maintain screenpipe. Happy to adjust the wording or section if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README with a new “Knowledge Management & Notes” example for Screenpipe, including a GitHub link, description of local-first recording with transcript/OCR indexing, licensing notes, and the project website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->