### PR TITLE
Add ygo (pure-Go Yjs port) to CRDT Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Loro](https://loro.dev/) – JSON and rich-text CRDT
 - [Collabs](https://collabs.readthedocs.io/en/latest/) – Composable CRDTs from CMU (low activity)
 - [Diamond Types](https://github.com/josephg/diamond-types) – High-performance Rust CRDT for text editing (WIP)
+- [ygo](https://github.com/Deln0r/ygo) – Pure-Go port of Yjs, wire-compatible with the JavaScript reference (V1/V2 update codecs, awareness, snapshots, subdocs)
 
 ### Frameworks & Platforms
 - [Jazz (CoJSON)](https://jazz.tools) – Local-first framework with built-in auth, sync, permissions, and E2E encryption


### PR DESCRIPTION
Adds [ygo](https://github.com/Deln0r/ygo) to the CRDT Libraries list.

ygo is a pure-Go port of Yjs, wire-compatible with the JavaScript reference (V1/V2 update codecs, awareness, snapshots, subdocuments), verified with bidirectional cross-language fixtures. It rounds out the CRDT section with a Go implementation alongside the JS/Rust ones. MIT licensed, v1.0.1, tests + CI + benchmarks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to include information about ygo, a pure-Go implementation of Yjs with wire compatibility for updates, awareness, snapshots, and subdocuments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->