### PR TITLE
Add LogZero (private on-device habit & health tracker) to Health & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 
 **Health & Fitness**
 - [nobro.app](https://nobro.app/) – Minimalist offline-first workout program tracker. State lives in localStorage, program is editable JSON, 11 locales
+- [LogZero](https://logzero.app) – All-in-one private habit and health tracker (mood, meds, food, exercise, weight) for iOS. 100% on-device with no account, no trackers, and zero network requests; AES-256 at rest with optional user-controlled encrypted export
 
 ### Learning Resources
 - [SQLite in Vue Guide](https://alexop.dev/posts/sqlite-vue3-offline-first-web-apps-guide/) – Building offline-first Vue apps


### PR DESCRIPTION
Adds **LogZero** to the **Example Applications → Health & Fitness** section.

LogZero is a local-first, all-in-one private habit and health tracker for iOS (mood, medication, food/calories, exercise, meditation, weight, to-dos, plus an on-device correlation engine and a streaks/insights dashboard). It fits the list's core criteria — data ownership and offline functionality:

- **100% on-device** — no account, no ads, no analytics/telemetry, and zero network requests for user data.
- **Offline-first** — all data lives locally on the device; the app works fully offline.
- **User-owned data** — AES-256 encryption at rest, with optional user-controlled encrypted export/backup (CSV/JSON/encrypted, Argon2 KDF).

It sits alongside the existing Health & Fitness entry (nobro.app) and the proprietary, no-account offline apps already listed (e.g. EchoTalk, Capacities, Reflect). Like those neighbors, the entry links to the product site rather than a source repo.

- Website: https://logzero.app
- App Store: https://apps.apple.com/app/id6773557137

Entry added (matches the neighboring format and en-dash style):

```
- [LogZero](https://logzero.app) – All-in-one private habit and health tracker (mood, meds, food, exercise, weight) for iOS. 100% on-device with no account, no trackers, and zero network requests; AES-256 at rest with optional user-controlled encrypted export
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Health & Fitness section to include information about LogZero, a private habit and health tracker for iOS with on-device operation, AES-256 encryption, and optional encrypted export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->