### PR TITLE
Add Meccha Chameleon Art fan atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,8 @@ Add tools, libraries, or case studies that advance **local-first**, **offline-fi
 
 ## 🪪 License
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0)
+
+## Community Resource Additions
+
+<!-- Added 2026-06-24 by zlc000190 -->
+- [Meccha Chameleon Art](https://mecchachameleon.art/) — Fan-made browser atlas of 50+ hiding spots for the Steam hide-and-seek game Meccha Chameleon. Bilingual (EN/中文), paint color analysis. GitHub awesome list: https://github.com/zlc000190/AwesomeMecchaChameleonHideSpot


### PR DESCRIPTION
## Community Resource

- [Meccha Chameleon Art](https://mecchachameleon.art/) — Fan-made browser atlas of 50+ hiding spots for the Steam hide-and-seek game Meccha Chameleon. Bilingual (EN/中文), paint color analysis.
- GitHub awesome list: https://github.com/zlc000190/AwesomeMecchaChameleonHideSpot

Fan-made, unofficial. Meccha Chameleon is © LEMORION.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Community Resources section to documentation featuring community-contributed resources and curated additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->