### PR TITLE
Add Vestige

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Obsidian](https://obsidian.md) – Markdown-based knowledge management with local vault storage
 - [SwarmVault](https://swarmvault.ai) – Local-first RAG knowledge vault. Compiles raw sources into a durable markdown wiki with a knowledge graph and hybrid SQLite FTS plus embeddings. All data lives on disk; AI access via a local MCP server.
 - [Memex](https://github.com/memex-lab/memex) – Open-source, local-first AI journal for iOS and Android. A multi-agent system turns text, photo, and voice fragments into structured timeline cards, and organizes knowledge using the P.A.R.A. methodology. All data is stored on-device (filesystem + SQLite) and users bring their own LLM provider. [Website](https://www.memexlab.ai/)
+- [Vestige](https://github.com/samvallad33/vestige) – Local-first cognitive memory server for AI coding agents. Stores memories in SQLite, runs as a Rust MCP server, and supports retention, correction, provenance, and local dashboard inspection.
 
 **Language Learning**
 - [EchoTalk](https://alisolphp.github.io/EchoTalk/) – Privacy-first offline shadowing practice PWA. AI pronunciation feedback, local recordings, no account needed.


### PR DESCRIPTION
## Summary
- Adds Vestige as a local-first knowledge/memory application for AI coding agents.
- Highlights local SQLite storage, Rust MCP runtime, retention/correction/provenance behavior, and dashboard inspection.

## Test plan
- [x] Checked for duplicate Vestige entry.
- [x] Ran git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Example Applications” entry: **Vestige**.
  * Included a brief description of its local-first cognitive memory approach, server-based workflow, and features like retention, correction, provenance, and dashboard inspection.
  * Added a link to the project to make it easier to find.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->