### PR TITLE
Add loro-go to CRDT Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Automerge](https://automerge.org) – CRDT library with fast binary format & WASM support (v3.0 with 10x memory reduction)
 - [Yjs](https://docs.yjs.dev/) – High-performance CRDT framework
 - [Loro](https://loro.dev/) – JSON and rich-text CRDT
+- [loro-go](https://github.com/Deln0r/loro-go) – Pure-Go library for the Loro CRDT wire format (decode, merge, encode; no cgo)
 - [Collabs](https://collabs.readthedocs.io/en/latest/) – Composable CRDTs from CMU (low activity)
 - [Diamond Types](https://github.com/josephg/diamond-types) – High-performance Rust CRDT for text editing (WIP)
 


### PR DESCRIPTION
Adds loro-go to the CRDT Libraries section.

loro-go is an independent pure-Go implementation of the Loro wire format: it decodes FastUpdates and FastSnapshot blobs, reconstructs CRDT state, and encodes blobs that are byte-identical to loro-crdt, with no cgo. Loro itself is already listed; this is a separate Go library that interoperates with it byte-for-byte.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new resource entry under the CRDT Libraries section of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->