### PR TITLE
Add Vibes DIY to Frameworks & Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Hocuspocus](https://github.com/ueberdosis/hocuspocus) – Yjs WebSocket backend with persistence and authorization
 - [Cloudflare Durable Objects](https://developers.cloudflare.com/durable-objects/) – Edge-deployed stateful primitives with built-in SQLite (cloud infrastructure)
 - [Earthstar](https://earthstar-project.org) – Offline-first P2P sync protocol for small-group collaboration
-- [Vibes DIY](https://vibes.diy/) – AI app builder that generates React apps backed by a local-first database (Fireproof), live and shareable at their own URL
+- [Vibes DIY](https://vibes.diy/) – [Open-source](https://github.com/VibesDIY/vibes.diy) AI app builder that generates React apps backed by a local-first database (Fireproof), live and shareable at their own URL
 
 ### P2P & Networking
 - [libp2p](https://libp2p.io) – Modular P2P networking stack supporting TCP, QUIC, WebRTC, and WebTransport

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Hocuspocus](https://github.com/ueberdosis/hocuspocus) – Yjs WebSocket backend with persistence and authorization
 - [Cloudflare Durable Objects](https://developers.cloudflare.com/durable-objects/) – Edge-deployed stateful primitives with built-in SQLite (cloud infrastructure)
 - [Earthstar](https://earthstar-project.org) – Offline-first P2P sync protocol for small-group collaboration
+- [Vibes DIY](https://vibes.diy/) – AI app builder that generates React apps backed by a local-first database (Fireproof), live and shareable at their own URL
 
 ### P2P & Networking
 - [libp2p](https://libp2p.io) – Modular P2P networking stack supporting TCP, QUIC, WebRTC, and WebTransport


### PR DESCRIPTION
Adds [Vibes DIY](https://vibes.diy/) under **Development Tools & Libraries → Frameworks & Platforms**.

Vibes DIY is an AI app builder that generates React apps backed by a **local-first database (Fireproof)** — which is already listed here under Database Solutions. You describe an app in plain English and get a live, shareable app with local-first data and real-time collaboration. Open source (Apache-2.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Frameworks & Platforms” entry for Vibes DIY, including its link and a short description of the platform (an AI app builder that generates React apps backed by a local-first database, with live/shareable URLs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->