### PR TITLE
Add Vestige (local-first memory for AI coding agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 **Health & Fitness**
 - [nobro.app](https://nobro.app/) – Minimalist offline-first workout program tracker. State lives in localStorage, program is editable JSON, 11 locales
 
+- [Vestige](https://github.com/samvallad33/vestige) - Local-first memory for AI coding agents. Finds the root cause of a bug by reaching backward in time to the quiet change that caused it (shared entity, not keyword similarity), the thing a vector search cannot do. One Rust binary, no cloud, data stays on your machine.
 ### Learning Resources
 - [SQLite in Vue Guide](https://alexop.dev/posts/sqlite-vue3-offline-first-web-apps-guide/) – Building offline-first Vue apps
 - [An Interactive Intro to CRDTs](https://jakelazaroff.com/words/an-interactive-intro-to-crdts/) – Hands-on tutorial


### PR DESCRIPTION
Adding Vestige under Example Applications.

It is local-first in the way this list cares about: one Rust binary, everything stored on your own machine in SQLite, no cloud and no telemetry. I built it because I kept losing days to bugs whose real cause was a quiet change from days earlier that looked nothing like the crash, and every memory tool I tried searched for what looked like the error instead of what caused it.

So it reaches backward in time and surfaces the earlier memory that actually caused the failure, matched on a shared entity (same file, env var, service) rather than keyword similarity. Data ownership plus offline-first plus a real reason to exist, which felt like a fit for this list.

npm install -g vestige-mcp-server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new example application entry for Vestige in the Example Applications section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->