### PR TITLE
Add Local MCP (local-first AI ↔ Mac apps bridge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 
 **Productivity & Collaboration**
 - [Excalidraw](https://excalidraw.com) – Collaborative drawing
+- [Local MCP](https://local-mcp.com) – Local-first bridge between AI assistants and a Mac's real apps. Connects Claude, Cursor, ChatGPT and other MCP clients to Mail, Calendar, iMessage, Teams, Slack, WhatsApp, Notes, files, OneDrive and Office docs — tools run on-device (EventKit/JXA/local stores), no API keys or OAuth. For desktop/CLI clients nothing leaves the machine; an optional opt-in encrypted relay lets web AIs reach the same local Mac. macOS, free.
 - [tldraw](https://tldraw.com) – Open-source infinite canvas whiteboard SDK
 - [Huly](https://huly.io) – Open-source all-in-one project management platform with offline-first client
 - [Superhuman](https://superhuman.com) – Offline-first email client


### PR DESCRIPTION
Adds **Local MCP** as a real-world local-first example under *Productivity & Collaboration*.

It's a local-first bridge between AI assistants (Claude, Cursor, ChatGPT, any MCP client) and a Mac's real apps — Mail, Calendar, iMessage, Teams, Slack, WhatsApp, Notes, files, OneDrive, Office. Tools run **on-device** (EventKit / JXA / local stores), no API keys or OAuth. For desktop/CLI clients nothing leaves the machine; an optional, opt-in encrypted relay lets web AIs reach the same local Mac. macOS, free.

Fits alongside the existing AI/MCP local-first entries (e.g. SwarmVault, Memex) — it applies the local-first principle to agent tool use: the model gets full local context without the data going through a cloud API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new **Local MCP** entry in the example applications section.
  * Described it as a local-first bridge for connecting AI assistants to Mac apps and tools, with on-device execution and an optional encrypted relay for web-based AIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->