### PR TITLE
Add Routines to Example Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Obsidian](https://obsidian.md) – Markdown-based knowledge management with local vault storage
 - [SwarmVault](https://swarmvault.ai) – Local-first RAG knowledge vault. Compiles raw sources into a durable markdown wiki with a knowledge graph and hybrid SQLite FTS plus embeddings. All data lives on disk; AI access via a local MCP server.
 - [Memex](https://github.com/memex-lab/memex) – Open-source, local-first AI journal for iOS and Android. A multi-agent system turns text, photo, and voice fragments into structured timeline cards, and organizes knowledge using the P.A.R.A. methodology. All data is stored on-device (filesystem + SQLite) and users bring their own LLM provider. [Website](https://www.memexlab.ai/)
+- [Routines](https://getroutines.ai) – Local-first macOS agentic AI. Meeting notes, dictation, clipboard, and screenshots feed a private markdown brain (Markdown + SQLite on disk); schedule AI agents by time or system triggers, bring your own model key (Claude, GPT, OpenRouter), and nothing is uploaded.
 
 **Language Learning**
 - [EchoTalk](https://alisolphp.github.io/EchoTalk/) – Privacy-first offline shadowing practice PWA. AI pronunciation feedback, local recordings, no account needed.


### PR DESCRIPTION
Adds Routines (https://getroutines.ai) under Real-World Examples > Example Applications > Knowledge Management & Notes.

Routines is a native macOS app in the same local-first cohort as SwarmVault and Memex already on the list: all user context (meeting notes, dictation, clipboard, screenshots) is stored on disk as Markdown + SQLite, never uploaded, and the AI is model-agnostic via a bring-your-own-key setup. It adds scheduled/triggered agentic "routines" on top of that local brain. Data ownership and offline-first are the core of the product, which is the list's thesis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an example application entry for Routines in the Knowledge Management & Notes section.
  * Clarified that it’s a local-first macOS app for storing notes, dictation, clipboard, and screenshot content locally.
  * Noted support for scheduled AI agents and the need to provide a model key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->