### PR TITLE
Add Oats to example applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Superhuman](https://superhuman.com) – Offline-first email client
 - [GitComet](https://github.com/Auto-Explore/GitComet) – Open-source (AGPL-3.0) local-first Git GUI in Rust for Linux, macOS, and Windows
 - [AI Workdeck](https://github.com/zeweihan/aiworkdeck) – Open-source AI-native workspace for legal and document-heavy workflows. Local-first with Ollama + local storage, OCR, due-diligence risk flagging, evidence-chain management, WPS WebOffice integration. Self-hosted (Java/Spring Boot + Vue + Electron + Docker, AGPLv3).
+- [OATS](https://github.com/ariso-ai/oats) – Open-source macOS menu bar meeting-notes app with live transcription, speaker labels, AI summaries, and an optional fully offline on-device mode.
 
 **Personal & Finance**
 - [Actual](https://actualbudget.com) – Local-first budgeting

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Superhuman](https://superhuman.com) – Offline-first email client
 - [GitComet](https://github.com/Auto-Explore/GitComet) – Open-source (AGPL-3.0) local-first Git GUI in Rust for Linux, macOS, and Windows
 - [AI Workdeck](https://github.com/zeweihan/aiworkdeck) – Open-source AI-native workspace for legal and document-heavy workflows. Local-first with Ollama + local storage, OCR, due-diligence risk flagging, evidence-chain management, WPS WebOffice integration. Self-hosted (Java/Spring Boot + Vue + Electron + Docker, AGPLv3).
-- [OATS](https://github.com/ariso-ai/oats) – Open-source macOS menu bar meeting-notes app with live transcription, speaker labels, AI summaries, and an optional fully offline on-device mode.
+- [OATS](https://github.com/ariso-ai/oats) – Open-source local-first macOS meeting-notes app with live transcription, speaker labels, AI summaries, and an optional fully offline on-device mode.
 
 **Personal & Finance**
 - [Actual](https://actualbudget.com) – Local-first budgeting


### PR DESCRIPTION
## Summary

Adds Oats, an open-source local-first macOS meeting-notes app with live transcription, speaker labels, AI summaries, and an optional fully offline on-device mode.

I placed it under Example Applications > Productivity & Collaboration because it is an offline-capable end-user app rather than a sync library.

## Checks

- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OATS to the list of example applications.
  * Documented its live transcription, speaker labeling, AI summaries, and optional offline mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->