### PR TITLE
Add CodeAlmanac

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Logseq](https://logseq.com) – Local-first knowledge base and outliner
 - [Obsidian](https://obsidian.md) – Markdown-based knowledge management with local vault storage
 - [SwarmVault](https://swarmvault.ai) – Local-first RAG knowledge vault. Compiles raw sources into a durable markdown wiki with a knowledge graph and hybrid SQLite FTS plus embeddings. All data lives on disk; AI access via a local MCP server.
+- [CodeAlmanac](https://github.com/AlmanacCode/codealmanac) – Repo-local Markdown wiki for AI coding agents. Project conversations, decisions, and context live inside the repository and can be used offline.
 - [Memex](https://github.com/memex-lab/memex) – Open-source, local-first AI journal for iOS and Android. A multi-agent system turns text, photo, and voice fragments into structured timeline cards, and organizes knowledge using the P.A.R.A. methodology. All data is stored on-device (filesystem + SQLite) and users bring their own LLM provider. [Website](https://www.memexlab.ai/)
 
 **Language Learning**


### PR DESCRIPTION
Adds CodeAlmanac to the Knowledge Management & Notes subsection.

Why it fits:
- stores its wiki as Markdown inside the local repository
- works as a local project knowledge layer for AI coding agents
- project context remains available offline and reviewable in git

Validation:
- read the contributing note in README.md
- ran `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “CodeAlmanac” example to the Knowledge Management & Notes section.
  * Included a GitHub link and brief description of the Markdown wiki for AI coding agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->