### PR TITLE
Add Recipe Jar to Example Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [nobro.app](https://nobro.app/) – Minimalist offline-first workout program tracker. State lives in localStorage, program is editable JSON, 11 locales
 
 **Food & Cooking**
-- [Recipe Jar](https://recipejar.app) – Local-first recipe keeper with no backend or database. Paste a link and it saves a clean, ad-free card to your browser's IndexedDB: unlimited recipes, fully offline as a PWA, one-file export for backups. Open source (Svelte 5).
+- [Recipe Jar](https://recipejar.app) – Local-first recipe keeper with no database: recipes live in your browser's IndexedDB. Paste a link to save a clean, ad-free card; unlimited recipes, fully offline as a PWA, one-file export for backups. The only server is a stateless fetch proxy that stores nothing. Open source (Svelte 5).
 
 ### Learning Resources
 - [SQLite in Vue Guide](https://alexop.dev/posts/sqlite-vue3-offline-first-web-apps-guide/) – Building offline-first Vue apps

--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 **Health & Fitness**
 - [nobro.app](https://nobro.app/) – Minimalist offline-first workout program tracker. State lives in localStorage, program is editable JSON, 11 locales
 
+**Food & Cooking**
+- [Recipe Jar](https://recipejar.app) – Local-first recipe keeper with no backend or database. Paste a link and it saves a clean, ad-free card to your browser's IndexedDB: unlimited recipes, fully offline as a PWA, one-file export for backups. Open source (Svelte 5).
+
 ### Learning Resources
 - [SQLite in Vue Guide](https://alexop.dev/posts/sqlite-vue3-offline-first-web-apps-guide/) – Building offline-first Vue apps
 - [An Interactive Intro to CRDTs](https://jakelazaroff.com/words/an-interactive-intro-to-crdts/) – Hands-on tutorial


### PR DESCRIPTION
Adds Recipe Jar under a new Food & Cooking group in Example Applications.

It is a genuinely local-first recipe keeper: no application server and no database, recipes live in the browser's IndexedDB on the device, and the only backend is a stateless fetch proxy that stores nothing. Unlimited saves, fully offline as a PWA, and a one-file JSON export you can point at any synced folder for backup. Open source (MIT), built with Svelte 5.

- Live: https://recipejar.app
- Source: https://github.com/sbmagar13/recipe-jar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Example Applications” section with a new **“Food & Cooking”** subsection.
  * Added **“Recipe Jar”** as a featured entry, highlighting its local-first, fully offline PWA experience, recipe storage, and one-file export for backups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->