### PR TITLE
Add Archery Note to Example Applications > Health & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Timelinize (2025)](https://timelinize.com) – Local data aggregation into a personal timeline
 
 **Health & Fitness**
+- [Archery Note](https://eita115115.github.io/archery-note/) – Privacy-first archery practice notebook PWA. Scoring, sight marks, equipment, and on-device AI form tracking (MediaPipe pose). All data lives in localStorage; no account, no server, works offline. Open source (Apache-2.0, vanilla JS, no bundler).
 - [nobro.app](https://nobro.app/) – Minimalist offline-first workout program tracker. State lives in localStorage, program is editable JSON, 11 locales
 
 **Food & Cooking**


### PR DESCRIPTION
Adding archery-note to Example Applications > Health & Fitness.

**Project**: Archery Note
**Repo**: https://github.com/eita115115/archery-note
**Live demo**: https://eita115115.github.io/archery-note/
**License**: Apache-2.0
**One-liner**: Privacy-first archery practice notebook PWA — scoring, sight marks, equipment, and on-device AI form tracking. No account, no ads, works offline.

**Why it fits**: It's a strict local-first PWA — all data lives in the user's browser storage (localStorage), there's no backend or account, and it works fully offline after first load. It sits naturally next to `nobro.app` in the same subsection: another single-domain practice tracker built around localStorage as the source of truth. The on-device MediaPipe pose analysis for form tracking is also local-first in spirit — no video ever leaves the device.

Full disclosure: I'm the author, and the repo is young (about a month, 1 star). If you'd prefer to wait until it has more traction, or a different placement, happy to iterate or close.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added “Archery Note” to the curated Health & Fitness examples list, including a description and link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->