### PR TITLE
Add ParquetKit to Example Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Superhuman](https://superhuman.com) – Offline-first email client
 - [GitComet](https://github.com/Auto-Explore/GitComet) – Open-source (AGPL-3.0) local-first Git GUI in Rust for Linux, macOS, and Windows
 - [AI Workdeck](https://github.com/zeweihan/aiworkdeck) – Open-source AI-native workspace for legal and document-heavy workflows. Local-first with Ollama + local storage, OCR, due-diligence risk flagging, evidence-chain management, WPS WebOffice integration. Self-hosted (Java/Spring Boot + Vue + Electron + Docker, AGPLv3).
+- [ParquetKit](https://parquetkit.com) – Local-first Parquet viewer, SQL workbench, and converter running entirely in the browser via DuckDB-WASM — files never leave your device
 
 **Personal & Finance**
 - [Actual](https://actualbudget.com) – Local-first budgeting


### PR DESCRIPTION
**What it is**: [ParquetKit](https://parquetkit.com) — a local-first Parquet viewer, SQL workbench and converter running entirely in the browser via DuckDB-WASM.

**Why it fits**: no backend at all (static site) — files are processed on-device and never uploaded, and the tools keep working offline once the engine is cached.

MIT licensed: https://github.com/XxxKMSxxX/parquetkit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ParquetKit to the list of example applications.
  * Documented its browser-based Parquet viewing, SQL workbench, and conversion capabilities with on-device file processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->