### PR TITLE
Add Kaiord to Health & Fitness example applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 
 **Health & Fitness**
 - [nobro.app](https://nobro.app/) – Minimalist offline-first workout program tracker. State lives in localStorage, program is editable JSON, 11 locales
+- [Kaiord](https://kaiord.com) – Open-source, local-first training platform: weekly calendar, visual workout editor, AI assistant, and Garmin & WHOOP sync. All data lives in the browser's IndexedDB; converts FIT, TCX, ZWO, and Garmin Connect workout files entirely client-side, with optional sync to your own Google Drive (MIT, TypeScript)
 
 **Food & Cooking**
 - [Recipe Jar](https://recipejar.app) – Local-first recipe keeper with no database: recipes live in your browser's IndexedDB. Paste a link to save a clean, ad-free card; unlimited recipes, fully offline as a PWA, one-file export for backups. The only server is a stateless fetch proxy that stores nothing. Open source (Svelte 5).


### PR DESCRIPTION
Adds [Kaiord](https://kaiord.com) ([GitHub](https://github.com/pablo-albaladejo/kaiord)) under **Health & Fitness**.

Kaiord is an open-source (MIT, TypeScript) local-first training platform: weekly training calendar, visual workout editor, AI assistant, and Garmin & WHOOP sync via browser extensions using the user's own sessions. All data lives in the browser's IndexedDB — no accounts, no backend; workout-file conversion (FIT, TCX, ZWO, Garmin Connect) runs entirely client-side, with optional sync to the user's own Google Drive.

PR opened by Claude Code on behalf of the project author, @pablo-albaladejo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Kaiord to the Health & Fitness examples.
  * Documented its local-first training platform, client-side processing, and optional Google Drive synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->