### PR TITLE
Add Matrix protocol and Local-First Conf 2026 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Syncthing](https://syncthing.net) – Open-source continuous P2P file synchronization with E2E encryption
 - [Nostr](https://github.com/nostr-protocol/nostr) – Open relay-based protocol for decentralized publishing
 - [AT Protocol](https://atproto.com) – Bluesky's protocol with self-authenticating data and portable identity
+- [Matrix](https://matrix.org) – Open decentralized protocol for secure, federated real-time communication with E2E encryption
 - [Braid HTTP](https://braid.org) – IETF draft extending HTTP into a state synchronization protocol
 
 ### Mobile-Specific
@@ -218,6 +219,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 ---
 
 ## 🎤 Conferences & Talks
+- [Local-First Conf 2026](https://localfirstconf.com) – Berlin edition (July 2026): Kleppmann, Steve Ruiz (tldraw), Jeffrey Heer (Mosaic), Iroh, Matrix, atproto, and more
 - [Local-First Conf 2024 Videos](https://www.youtube.com/@localfirstconf/videos) – Sessions by Kleppmann, Artman (Linear), etc.
 - [LoFi / 28 Meetup (2025)](https://localfirstnews.com/lofi28) – Dexie, Replication 3 Ways, Legend State performance talk
 - [SyncConf 2025 Preview](https://localfirstconf.com/syncconf2025) – Dedicated sync-tech event


### PR DESCRIPTION
## Summary
Updated the README to include Matrix as a decentralized protocol example and added information about the upcoming Local-First Conf 2026 event.

## Key Changes
- Added Matrix to the "Decentralized Protocols" section with a description highlighting its open, federated nature and E2E encryption capabilities
- Added Local-First Conf 2026 (Berlin, July 2026) to the "Conferences & Talks" section, noting key speakers and topics including Kleppmann, Steve Ruiz, Jeffrey Heer, and coverage of Iroh, Matrix, and atproto

## Details
These additions enhance the README's coverage of relevant technologies and community events in the local-first ecosystem. Matrix is positioned alongside other decentralized protocols like Nostr and AT Protocol, while the 2026 conference entry is placed prominently at the top of the conferences list to highlight the upcoming event.

https://claude.ai/code/session_019CY2zjLrntiUo4EUmWyMym

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Matrix to the list of peer-to-peer and networking protocols.
  * Added Local-First Conf 2026, including Berlin event details and featured speakers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->