### PR TITLE
Add ferrovec to Database Solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [PGlite](https://github.com/electric-sql/pglite) – Embeddable Postgres in WASM with reactive live queries, multi-tab worker support, and full SQL
 - [Turbolite](https://github.com/russellromney/turbolite) – SQLite VFS enabling sub-100ms cold JOIN queries against S3 with page-level compression and encryption
 - [VelesDB](https://github.com/cyberlife-coder/VelesDB) – Local-first vector + graph + columnar database written in Rust (~6MB binary). Source-available (Elastic License 2.0)
+- [ferrovec](https://singhpratech.github.io/ferrovec/) – Browser-native semantic search: a Rust→WASM HNSW vector index (~33KB gzip) with OPFS persistence, offline embeddings (transformers.js), and cross-tab single-writer coordination. MIT
 
 ### State Management & Sync
 - [Legend State](https://github.com/LegendApp/legend-state) – Reactive state with persistence


### PR DESCRIPTION
Adding **[ferrovec](https://singhpratech.github.io/ferrovec/)** under Development Tools & Libraries → Database Solutions (next to VelesDB, another Rust local-first vector store).

ferrovec is a browser-native semantic-search store: a Rust→WASM HNSW vector index (~33 KB gzipped) that **persists to OPFS** so data survives reloads, embeds text on-device via transformers.js, and coordinates safely across tabs with single-writer leader election (Web Locks + BroadcastChannel). Nothing leaves the device — a genuinely local-first take on vector search. MIT, on npm + crates.io.

Live demo (runs offline): https://singhpratech.github.io/ferrovec/demo.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Ferrovec to the Database Solutions section, including a brief description and MIT license attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->