### PR TITLE
docs(example-applications): add Clawdbot.tech to Productivity & Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [Superhuman](https://superhuman.com) – Offline-first email client
 - [GitComet](https://github.com/Auto-Explore/GitComet) – Open-source (AGPL-3.0) local-first Git GUI in Rust for Linux, macOS, and Windows
 - [AI Workdeck](https://github.com/zeweihan/aiworkdeck) – Open-source AI-native workspace for legal and document-heavy workflows. Local-first with Ollama + local storage, OCR, due-diligence risk flagging, evidence-chain management, WPS WebOffice integration. Self-hosted (Java/Spring Boot + Vue + Electron + Docker, AGPLv3).
+- [Clawdbot.tech](https://clawdbot.tech/) – Multilingual deployment guide and configuration archive for the self-hosted [OpenClaw](https://openclaw.ai) AI agent. Local-first with 5-language install docs (EN/中/日/ES/FR), security white paper, and changelog covering the Clawdbot → Moltbot → OpenClaw rename history. Data lives on-device, no cloud account required.
 
 **Personal & Finance**
 - [Actual](https://actualbudget.com) – Local-first budgeting


### PR DESCRIPTION
## What's being added

Clawdbot.tech (https://clawdbot.tech/) — a community-maintained, multilingual
deployment guide and configuration archive for the self-hosted OpenClaw AI
agent.

## Why it fits Productivity & Collaboration

Clawdbot is a self-hosted, local-first AI agent. The deployment guide covers:

- **Local-first architecture**: data lives on-device, no cloud account required
- **Self-hosted**: Docker / bare-metal install paths, fully under user control
- **Multilingual**: 5-language install docs (English, 中文, 日本語, Español, Français)
- **Security-first**: published security white paper
- **Production battle-tested**: 91+ days continuous operation

## What makes this different from "general purpose AI agents" awesome-list entries

Clawdbot is **not an agent itself** — it is the deployment guide / configuration
archive for OpenClaw (an open-source agent). It belongs in this list in the
same category as [AI Workdeck](https://github.com/zeweihan/aiworkdeck)
(self-hosted AI workspace) and [GitComet](https://github.com/Auto-Explore/GitComet)
(self-hosted Git GUI) — self-hosted, local-first, AI-adjacent productivity tools.

## Maintenance commitment

- Actively maintained as of 2026-06
- 5-language documentation updated in lockstep with upstream OpenClaw releases
- Security white paper is republished on every major release
- GitHub-backed project with public commit history

## Checklist

- [x] Entry is for a self-hosted, local-first tool (matches section scope)
- [x] Entry is open-source / community-maintained
- [x] Description matches the existing "long-form + dash + tags" format in
      this section
- [x] No duplicate of existing entries (verified via grep -i "clawdbot\|openclaw"
      in README — 0 hits before this PR)
- [x] Anchor is `https://clawdbot.tech/` (not a tracking link)
- [x] Entry advances **local-first**, **offline-first**, or **sync-centric**
      development (per CONTRIBUTING.md scope statement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Clawdbot.tech to the list of example applications, highlighting its local-first, multilingual deployment and configuration features.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->