### PR TITLE
Add LCM Core Engine to local-first AI engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [SwarmVault](https://swarmvault.ai) – Local-first RAG knowledge vault. Compiles raw sources into a durable markdown wiki with a knowledge graph and hybrid SQLite FTS plus embeddings. All data lives on disk; AI access via a local MCP server.
 - [Memex](https://github.com/memex-lab/memex) – Open-source, local-first AI journal for iOS and Android. A multi-agent system turns text, photo, and voice fragments into structured timeline cards, and organizes knowledge using the P.A.R.A. methodology. All data is stored on-device (filesystem + SQLite) and users bring their own LLM provider. [Website](https://www.memexlab.ai/)
 - [Screenpipe](https://github.com/screenpipe/screenpipe) – Local-first screen and audio recorder that indexes OCR, accessibility data, and transcripts into a searchable timeline for people and AI agents. Data stays on disk by default; cross-platform (macOS/Windows/Linux); works with local models. Source-available under the Screenpipe Commercial License; earlier MIT-licensed versions remain under MIT. [Website](https://screenpipe.com)
-- [LCM Core Engine](https://github.com/hyanalcm-png/LCM-Core_engine) – A local-first neuro-symbolic AI engine with deterministic reasoning and multilingual caching.
+- [LCM Core Engine](https://github.com/hyanalcm-png/LCM-Core-Engine) - Local-first neuro-symbolic AI engine with deterministic reasoning and multilingual caching.
 
 **Language Learning**
 - [EchoTalk](https://alisolphp.github.io/EchoTalk/) – Privacy-first offline shadowing practice PWA. AI pronunciation feedback, local recordings, no account needed.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 - [SwarmVault](https://swarmvault.ai) – Local-first RAG knowledge vault. Compiles raw sources into a durable markdown wiki with a knowledge graph and hybrid SQLite FTS plus embeddings. All data lives on disk; AI access via a local MCP server.
 - [Memex](https://github.com/memex-lab/memex) – Open-source, local-first AI journal for iOS and Android. A multi-agent system turns text, photo, and voice fragments into structured timeline cards, and organizes knowledge using the P.A.R.A. methodology. All data is stored on-device (filesystem + SQLite) and users bring their own LLM provider. [Website](https://www.memexlab.ai/)
 - [Screenpipe](https://github.com/screenpipe/screenpipe) – Local-first screen and audio recorder that indexes OCR, accessibility data, and transcripts into a searchable timeline for people and AI agents. Data stays on disk by default; cross-platform (macOS/Windows/Linux); works with local models. Source-available under the Screenpipe Commercial License; earlier MIT-licensed versions remain under MIT. [Website](https://screenpipe.com)
+- [LCM Core Engine](https://github.com/hyanalcm-png/LCM-Core_engine) – A local-first neuro-symbolic AI engine with deterministic reasoning and multilingual caching.
 
 **Language Learning**
 - [EchoTalk](https://alisolphp.github.io/EchoTalk/) – Privacy-first offline shadowing practice PWA. AI pronunciation feedback, local recordings, no account needed.


### PR DESCRIPTION
Adding LCM Core Engine — a local-first neuro-symbolic AI engine with deterministic reasoning and multilingual caching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added LCM Core Engine to the list of example applications.
  * Described it as a local-first neuro-symbolic AI engine with deterministic reasoning and multilingual caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->