### PR TITLE
Add Vitra to Health & Fitness section

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 
 **Health & Fitness**
 - [nobro.app](https://nobro.app/) – Minimalist offline-first workout program tracker. State lives in localStorage, program is editable JSON, 11 locales
+- [Vitra](https://vitrahealth.app) – Local-first desktop companion for Oura Ring owners. Syncs your history once through the official API, then every calculation runs on your own Mac or PC. No account and no vendor cloud; full JSON, CSV and PDF export
 
 **Food & Cooking**
 - [Recipe Jar](https://recipejar.app) – Local-first recipe keeper with no database: recipes live in your browser's IndexedDB. Paste a link to save a clean, ad-free card; unlimited recipes, fully offline as a PWA, one-file export for backups. The only server is a stateless fetch proxy that stores nothing. Open source (Svelte 5).

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Local-first software prioritizes **data ownership**, **offline functionality**, 
 
 **Health & Fitness**
 - [nobro.app](https://nobro.app/) – Minimalist offline-first workout program tracker. State lives in localStorage, program is editable JSON, 11 locales
-- [Vitra](https://vitrahealth.app) – Local-first desktop companion for Oura Ring owners. Syncs your history once through the official API, then every calculation runs on your own Mac or PC. No account and no vendor cloud; full JSON, CSV and PDF export
+- [Vitra](https://vitrahealth.app) – Local-first desktop companion for Oura Ring owners. Imports your history and keeps it synced through the official API, and every calculation runs on your own Mac or PC. No Vitra account and no vendor cloud; full JSON, CSV and PDF export
 
 **Food & Cooking**
 - [Recipe Jar](https://recipejar.app) – Local-first recipe keeper with no database: recipes live in your browser's IndexedDB. Paste a link to save a clean, ad-free card; unlimited recipes, fully offline as a PWA, one-file export for backups. The only server is a stateless fetch proxy that stores nothing. Open source (Svelte 5).


### PR DESCRIPTION
Adds Vitra to the Health & Fitness section.

Vitra is a desktop companion for Oura Ring owners. It syncs your history once through Oura's official API and then does every calculation locally on your own Mac or PC — no account of its own, no vendor cloud holding the data, and full JSON, CSV and PDF export.

Disclosure: I build Vitra, so please treat this as a self-submission. It is proprietary and paid (one-time), which I see the list already accommodates alongside Figma, Notion and Superhuman. Happy to reword or drop it if it is not a fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Vitra description in the Health & Fitness example applications list.
  - Clarified that Vitra imports and continuously syncs history through the official API.
  - Clarified that a Vitra account is not required, while syncing still requires an Oura account.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->